### PR TITLE
add quotes around values when the value contains a quote

### DIFF
--- a/event/formatter/formatter.go
+++ b/event/formatter/formatter.go
@@ -82,7 +82,7 @@ func (formatter *Formatter) ToString(data interface{}) string {
 
 func needQuote(str string) bool {
 	for _, char := range str {
-		if unicode.IsSpace(char) || !unicode.IsPrint(char) {
+		if unicode.IsSpace(char) || !unicode.IsPrint(char) || unicode.Is(unicode.Quotation_Mark, char) {
 			return true
 		}
 	}


### PR DESCRIPTION
@MrGossett This fixes it so that if the value has a quote, it gets quoted. No more ambiguity whether the quote was part of the value, or added by sawmill.
