### PR TITLE
better repo root detection

### DIFF
--- a/handler/airbrake/airbrake_main_test.go
+++ b/handler/airbrake/airbrake_main_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,14 +17,6 @@ import (
 
 func init() {
 	event.RepoPath = event.FilePath
-
-	// `go test -cover` rewrites the source, and screws up the package detection
-	// of filePath.
-	// Fortunately it doesn't muck with the test code, so we just reset it here.
-	if false {
-		_, filePath, _, _ = runtime.Caller(0)
-		filePath = path.Dir(filePath) + "/airbrake.go"
-	}
 }
 
 func TestMain(m *testing.M) {
@@ -63,6 +53,7 @@ func (server *airbrakeSvr) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if server.projectID != projectID || server.projectKey != projectKey {
 		w.WriteHeader(http.StatusUnauthorized)
+		return
 	}
 
 	id := strconv.FormatInt(time.Now().UnixNano(), 10)

--- a/handler/airbrake/airbrake_test.go
+++ b/handler/airbrake/airbrake_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"runtime"
 	"testing"
 
@@ -70,14 +69,4 @@ func TestAirbrakeHandler(t *testing.T) {
 
 	nParams := notice["params"].(map[string]interface{})
 	assert.Equal(t, "bar", nParams["foo"])
-}
-
-func TestRepoRoot(t *testing.T) {
-	// assume this test file is `sawmill/handler/airbrake/airbrake_test.go`
-	_, gitRoot, _, _ := runtime.Caller(0)
-	gitRoot = path.Dir(path.Dir(path.Dir(gitRoot)))
-
-	repoRoot, repoVersion := repoInfo()
-	assert.Equal(t, gitRoot, repoRoot)
-	assert.NotEmpty(t, repoVersion)
 }

--- a/util/repo_info.go
+++ b/util/repo_info.go
@@ -1,0 +1,80 @@
+// The util package contains miscellaneous helper functions.
+
+package util
+
+import (
+	"bytes"
+	"os/exec"
+	"path"
+	"runtime"
+
+	"golang.org/x/tools/go/vcs"
+)
+
+// RepoInfo attempts to find the repo information for the caller, and returns
+// the path to the top of the repo, the commit ID, and the tag.
+func RepoInfo() (repoRoot string, repoRevision string, repoTag string) {
+	var vcsCmd *vcs.Cmd
+
+	// Walk up the call stack until we find main.main
+	for i := 1; ; i++ {
+		caller, file, _, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+
+		f := runtime.FuncForPC(caller)
+		if f == nil {
+			continue
+		}
+		if path.Base(f.Name()) == "main.main" {
+			repoRoot = path.Dir(file)
+			break
+		}
+
+		// see if we're in testing
+		if path.Base(f.Name()) == "testing.tRunner" {
+			// go back up one level
+			_, file, _, _ := runtime.Caller(i - 1)
+			repoRoot = path.Dir(file)
+			break
+		}
+	}
+
+	// Try and find the root of the VCS repo using repoRoot as a starting point.
+	if repoRoot != "" {
+		// walk up the dir until we get to the first directory in root.
+		// This is an unfortunately necessity to use vcs.FromDir()
+		topDir := repoRoot
+		for dir := path.Dir(topDir); dir != "." && dir[len(dir)-1] != '/' && dir != topDir; dir = path.Dir(topDir) {
+			topDir = dir
+		}
+
+		var vcsRoot string
+		vcsCmd, vcsRoot, _ = vcs.FromDir(path.Dir(repoRoot), topDir)
+		if len(vcsRoot) > 0 {
+			if vcsRoot[0] != '/' {
+				vcsRoot = topDir + "/" + vcsRoot
+			}
+			repoRoot = vcsRoot
+		}
+	}
+
+	if vcsCmd != nil && vcsCmd.Name == "Git" {
+		execCmd := exec.Command("git", "describe", "--dirty", "--match", "", "--always")
+		execCmd.Dir = repoRoot
+		output, err := execCmd.Output()
+		if err == nil {
+			repoRevision = string(bytes.TrimRight(output, "\n"))
+		}
+
+		execCmd = exec.Command("git", "describe", "--dirty", "--tags", "--always")
+		execCmd.Dir = repoRoot
+		output, err = execCmd.Output()
+		if err == nil {
+			repoTag = string(bytes.TrimRight(output, "\n"))
+		}
+	}
+
+	return
+}

--- a/util/repo_info_test.go
+++ b/util/repo_info_test.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"path"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepoRoot(t *testing.T) {
+	// assume this test file is `sawmill/util/repo_root_test.go`
+	_, gitRoot, _, _ := runtime.Caller(0)
+	gitRoot = path.Dir(path.Dir(gitRoot))
+
+	repoRoot, repoTag, repoVersion := RepoInfo()
+	assert.Equal(t, gitRoot, repoRoot)
+	assert.NotEmpty(t, repoTag)
+	assert.NotEmpty(t, repoVersion)
+}


### PR DESCRIPTION
If the app isn't in a known VCS repo, pull the repo root from the directory containing `main.main`.
