### PR TITLE
Export Channel and Capture Handlers

### DIFF
--- a/handler/capture/capture.go
+++ b/handler/capture/capture.go
@@ -1,0 +1,59 @@
+package capture
+
+import (
+	"sync"
+
+	"github.com/phemmer/sawmill/event"
+)
+
+// Handler captures events in a threadsafe slice.
+type Handler struct {
+	events []*event.Event
+	mutex  sync.Mutex
+}
+
+// NewHandler creates and returns a new Handler
+func NewHandler() *Handler {
+	return &Handler{
+		events: []*event.Event{},
+	}
+}
+
+// Event fills the sawmill.Handler interface
+func (handler *Handler) Event(logEvent *event.Event) error {
+	handler.mutex.Lock()
+	handler.events = append(handler.events, logEvent)
+	handler.mutex.Unlock()
+	return nil
+}
+
+// Last returns the last event captured
+func (handler *Handler) Last() *event.Event {
+	handler.mutex.Lock()
+	defer handler.mutex.Unlock()
+
+	l := len(handler.events)
+	if l == 0 {
+		return nil
+	}
+
+	logEvent := handler.events[l-1]
+	return logEvent
+}
+
+// Events returns the slice of captured events
+func (handler *Handler) Events() []*event.Event {
+	handler.mutex.Lock()
+	dst := make([]*event.Event, len(handler.events))
+	_ = copy(dst, handler.events)
+	handler.mutex.Unlock()
+
+	return dst
+}
+
+// Clear drops all captured events
+func (handler *Handler) Clear() {
+	handler.mutex.Lock()
+	handler.events = []*event.Event{}
+	handler.mutex.Unlock()
+}

--- a/handler/capture/capture.go
+++ b/handler/capture/capture.go
@@ -1,3 +1,9 @@
+// The capture handler maintains a threadsafe slice of *event.Event. Events are added to the slice
+// in the order that they are recieved. Provided for convenience:
+//
+//  * `Last()` func which returns the last event in the slice
+//  * `Events()` func which returns a copy of the events slice
+//  * `Clear()` func which drops all events in the slice
 package capture
 
 import (
@@ -41,7 +47,7 @@ func (handler *Handler) Last() *event.Event {
 	return logEvent
 }
 
-// Events returns the slice of captured events
+// Events returns a slice of captured events
 func (handler *Handler) Events() []*event.Event {
 	handler.mutex.Lock()
 	dst := make([]*event.Event, len(handler.events))

--- a/handler/capture/capture_test.go
+++ b/handler/capture/capture_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_Handler_iface(t *testing.T) {
+func TestHandlerIface(t *testing.T) {
 	assert.Implements(t, (*sawmill.Handler)(nil), NewHandler())
 }
 
-func Test_Event(t *testing.T) {
+func TestEvent(t *testing.T) {
 	ch := NewHandler()
 	logEvent0 := makeEvent(0)
 	logEvent1 := makeEvent(1)
@@ -28,7 +28,7 @@ func Test_Event(t *testing.T) {
 	assert.Equal(t, logEvent2, ch.events[2])
 }
 
-func Test_Last(t *testing.T) {
+func TestLast(t *testing.T) {
 	ch := NewHandler()
 	logEvent2 := makeEvent(2)
 
@@ -39,13 +39,13 @@ func Test_Last(t *testing.T) {
 	assert.Equal(t, logEvent2, ch.Last())
 }
 
-func Test_Last_empty(t *testing.T) {
+func TestLastEmpty(t *testing.T) {
 	ch := NewHandler()
 
 	assert.Nil(t, ch.Last())
 }
 
-func Test_Events(t *testing.T) {
+func TestEvents(t *testing.T) {
 	ch := NewHandler()
 	events := []*event.Event{
 		makeEvent(0),
@@ -60,7 +60,7 @@ func Test_Events(t *testing.T) {
 	assert.Equal(t, events, ch.Events())
 }
 
-func Test_Clear(t *testing.T) {
+func TestClear(t *testing.T) {
 	ch := NewHandler()
 	for i := 0; i < 5; i++ {
 		ch.Event(makeEvent(0))

--- a/handler/capture/capture_test.go
+++ b/handler/capture/capture_test.go
@@ -1,0 +1,88 @@
+package capture
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/phemmer/sawmill"
+	"github.com/phemmer/sawmill/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Handler_iface(t *testing.T) {
+	assert.Implements(t, (*sawmill.Handler)(nil), NewHandler())
+}
+
+func Test_Event(t *testing.T) {
+	ch := NewHandler()
+	logEvent0 := makeEvent(0)
+	logEvent1 := makeEvent(1)
+	logEvent2 := makeEvent(2)
+
+	ch.Event(logEvent0)
+	ch.Event(logEvent1)
+	ch.Event(logEvent2)
+
+	assert.Equal(t, logEvent0, ch.events[0])
+	assert.Equal(t, logEvent1, ch.events[1])
+	assert.Equal(t, logEvent2, ch.events[2])
+}
+
+func Test_Last(t *testing.T) {
+	ch := NewHandler()
+	logEvent2 := makeEvent(2)
+
+	ch.Event(makeEvent(0))
+	ch.Event(makeEvent(1))
+	ch.Event(logEvent2)
+
+	assert.Equal(t, logEvent2, ch.Last())
+}
+
+func Test_Last_empty(t *testing.T) {
+	ch := NewHandler()
+
+	assert.Nil(t, ch.Last())
+}
+
+func Test_Events(t *testing.T) {
+	ch := NewHandler()
+	events := []*event.Event{
+		makeEvent(0),
+		makeEvent(1),
+		makeEvent(2),
+	}
+
+	for _, e := range events {
+		ch.Event(e)
+	}
+
+	assert.Equal(t, events, ch.Events())
+}
+
+func Test_Clear(t *testing.T) {
+	ch := NewHandler()
+	for i := 0; i < 5; i++ {
+		ch.Event(makeEvent(0))
+	}
+	assert.Len(t, ch.events, 5)
+
+	ch.Clear()
+
+	assert.Len(t, ch.events, 0)
+}
+
+var eventCounter uint64
+
+func makeEvent(level event.Level) *event.Event {
+	eventCounter++
+
+	callerPC, _, _, _ := runtime.Caller(1)
+	callerFunc := runtime.FuncForPC(callerPC)
+	callerName := callerFunc.Name()
+
+	message := "testing " + callerName + "()"
+	data := map[string]interface{}{"test": callerName}
+
+	return event.New(eventCounter, level, message, data, false)
+}

--- a/handler/channel/channel.go
+++ b/handler/channel/channel.go
@@ -1,0 +1,43 @@
+package channel
+
+import (
+	"time"
+
+	"github.com/phemmer/sawmill/event"
+)
+
+// Handler sends log events to an unbuffered chan *event.Event. Events are read with Next().
+type Handler struct {
+	channel chan *event.Event
+}
+
+// NewHandler creates and returns a new Handler
+func NewHandler() *Handler {
+	return &Handler{
+		channel: make(chan *event.Event),
+	}
+}
+
+// Event fills the sawmill.Handler interface for logging events
+func (handler *Handler) Event(logEvent *event.Event) error {
+	handler.channel <- logEvent
+	return nil
+}
+
+// Next returns the next event by reading from channel, with an optional timeout. If timeout
+// is 0, then Next performs a non-blocking read.
+func (handler *Handler) Next(timeout time.Duration) *event.Event {
+	var logEvent *event.Event
+	if timeout == 0 {
+		select {
+		case logEvent = <-handler.channel:
+		default:
+		}
+	} else {
+		select {
+		case logEvent = <-handler.channel:
+		case <-time.After(timeout):
+		}
+	}
+	return logEvent
+}

--- a/handler/channel/channel.go
+++ b/handler/channel/channel.go
@@ -1,3 +1,9 @@
+// The channel handler provides an unbuffered `chan *event.Event`
+// onto which each recieved event is written. Events are read from the chan
+// using `Next()`.
+//
+// NB: since the `chan *event.Event` is unbuffered, `Event()` will block until some other
+// goroutine reads from the chan.
 package channel
 
 import (

--- a/handler/channel/channel_test.go
+++ b/handler/channel/channel_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_Handler_iface(t *testing.T) {
+func TestHandlerIface(t *testing.T) {
 	assert.Implements(t, (*sawmill.Handler)(nil), NewHandler())
 }
 
-func Test_Event(t *testing.T) {
+func TestEvent(t *testing.T) {
 	ch := NewHandler()
 	logEvent := makeEvent(0)
 	go ch.Event(logEvent)
@@ -28,7 +28,7 @@ func Test_Event(t *testing.T) {
 	assert.Equal(t, logEvent, chEvent)
 }
 
-func Test_Next(t *testing.T) {
+func TestNext(t *testing.T) {
 	ch := NewHandler()
 	logEvent := makeEvent(0)
 	go func() { ch.channel <- logEvent }()
@@ -38,7 +38,7 @@ func Test_Next(t *testing.T) {
 	assert.Equal(t, logEvent, chEvent)
 }
 
-func Test_Next_timeout(t *testing.T) {
+func TestNextTimeout(t *testing.T) {
 	ch := NewHandler()
 
 	chEvent := ch.Next(time.Nanosecond)
@@ -46,7 +46,7 @@ func Test_Next_timeout(t *testing.T) {
 	assert.Nil(t, chEvent)
 }
 
-func Test_Next_nonblocking(t *testing.T) {
+func TestNextNonblocking(t *testing.T) {
 	ch := NewHandler()
 	logEvent := makeEvent(0)
 	go func() {

--- a/handler/channel/channel_test.go
+++ b/handler/channel/channel_test.go
@@ -1,0 +1,75 @@
+package channel
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/phemmer/sawmill"
+	"github.com/phemmer/sawmill/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Handler_iface(t *testing.T) {
+	assert.Implements(t, (*sawmill.Handler)(nil), NewHandler())
+}
+
+func Test_Event(t *testing.T) {
+	ch := NewHandler()
+	logEvent := makeEvent(0)
+	go ch.Event(logEvent)
+
+	var chEvent *event.Event
+	select {
+	case chEvent = <-ch.channel:
+	case <-time.After(time.Millisecond):
+	}
+
+	assert.Equal(t, logEvent, chEvent)
+}
+
+func Test_Next(t *testing.T) {
+	ch := NewHandler()
+	logEvent := makeEvent(0)
+	go func() { ch.channel <- logEvent }()
+
+	chEvent := ch.Next(time.Millisecond)
+
+	assert.Equal(t, logEvent, chEvent)
+}
+
+func Test_Next_timeout(t *testing.T) {
+	ch := NewHandler()
+
+	chEvent := ch.Next(time.Nanosecond)
+
+	assert.Nil(t, chEvent)
+}
+
+func Test_Next_nonblocking(t *testing.T) {
+	ch := NewHandler()
+	logEvent := makeEvent(0)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		ch.channel <- logEvent
+	}()
+
+	chEvent := ch.Next(time.Duration(0))
+
+	assert.Nil(t, chEvent)
+}
+
+var eventCounter uint64
+
+func makeEvent(level event.Level) *event.Event {
+	eventCounter++
+
+	callerPC, _, _, _ := runtime.Caller(1)
+	callerFunc := runtime.FuncForPC(callerPC)
+	callerName := callerFunc.Name()
+
+	message := "testing " + callerName + "()"
+	data := map[string]interface{}{"test": callerName}
+
+	return event.New(eventCounter, level, message, data, false)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -8,12 +8,13 @@ import (
 	"time"
 
 	"github.com/phemmer/sawmill/event"
+	"github.com/phemmer/sawmill/handler/channel"
 	"github.com/phemmer/sawmill/handler/filter"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLoggerEvent(t *testing.T) {
-	handler := NewChannelHandler()
+	handler := channel.NewHandler()
 
 	logger := NewLogger()
 	logger.AddHandler("TestEvent", handler)
@@ -30,7 +31,7 @@ func TestLoggerEvent(t *testing.T) {
 
 // this makes sure that a removed handler processes no further events
 func TestLoggerRemoveHandler(t *testing.T) {
-	handler := NewChannelHandler()
+	handler := channel.NewHandler()
 
 	logger := NewLogger()
 	logger.AddHandler("TestEvent", handler)
@@ -43,7 +44,7 @@ func TestLoggerRemoveHandler(t *testing.T) {
 
 // check that removing a handler already removed doesn't error
 func TestLoggerRemoveHandlerTwice(t *testing.T) {
-	handler := NewChannelHandler()
+	handler := channel.NewHandler()
 
 	logger := NewLogger()
 	logger.AddHandler("TestEvent", handler)
@@ -53,7 +54,7 @@ func TestLoggerRemoveHandlerTwice(t *testing.T) {
 
 // check that removing a handler waits for the handler to finish processing
 func TestLoggerRemoveHandlerWait(t *testing.T) {
-	handler := NewChannelHandler()
+	handler := channel.NewHandler()
 
 	logger := NewLogger()
 	logger.AddHandler("TestEvent", handler)
@@ -64,7 +65,7 @@ func TestLoggerRemoveHandlerWait(t *testing.T) {
 	assert.Equal(t, logger.eventHandlerMap["TestEvent"].lastSentEventId, eventId1)
 	assert.NotEqual(t, logger.eventHandlerMap["TestEvent"].lastProcessedEventId, eventId1)
 
-	// send a second event, just so we have one that's not sitting on the channelHandler channel
+	// send a second event, just so we have one that's not sitting on the channel.Handler channel
 	eventId2 := logger.Event(InfoLevel, "TestEvent")
 	assert.Equal(t, logger.eventHandlerMap["TestEvent"].lastSentEventId, eventId2)
 	assert.NotEqual(t, logger.eventHandlerMap["TestEvent"].lastProcessedEventId, eventId2)
@@ -85,11 +86,11 @@ func TestLoggerRemoveHandlerWait(t *testing.T) {
 func TestLoggerAddDuplicateHandler(t *testing.T) {
 	logger := NewLogger()
 
-	handler1 := NewChannelHandler()
+	handler1 := channel.NewHandler()
 	logger.AddHandler("TestEvent", handler1)
 	defer logger.RemoveHandler("TestEvent", false)
 
-	handler2 := NewChannelHandler()
+	handler2 := channel.NewHandler()
 	logger.AddHandler("TestEvent", handler2)
 
 	logger.Event(InfoLevel, "TestEvent")
@@ -101,7 +102,7 @@ func TestLoggerAddDuplicateHandler(t *testing.T) {
 func TestLoggerFilterHandler(t *testing.T) {
 	logger := NewLogger()
 
-	channelHandler := NewChannelHandler()
+	channelHandler := channel.NewHandler()
 
 	handler := logger.FilterHandler(channelHandler)
 	assert.IsType(t, &filter.FilterHandler{}, handler)
@@ -111,7 +112,7 @@ func TestLoggerHelpers(t *testing.T) {
 	logger := NewLogger()
 	defer logger.Stop()
 
-	handler := NewChannelHandler()
+	handler := channel.NewHandler()
 	logger.AddHandler("TestEvent", handler)
 
 	type testLoggerHelper struct {
@@ -157,7 +158,7 @@ func TestLoggerFatal(t *testing.T) {
 	logger := NewLogger()
 	defer logger.Stop()
 
-	handler := NewChannelHandler()
+	handler := channel.NewHandler()
 	logger.AddHandler("TestEvent", handler)
 
 	// logger.Fatal performs a Stop(), which waits for the handler to process the event. So we have to process it or we deadlock. We do this by starting a goroutine
@@ -190,13 +191,13 @@ func TestLoggerCheckPanic(t *testing.T) {
 	}()
 
 	logger := NewLogger()
-	handler := NewChannelHandler()
+	handler := channel.NewHandler()
 	logger.AddHandler("TestLoggerCheckPanic", handler)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		// goroutine is because the channelHandler is unbuffered, meaning the
+		// goroutine is because the channel.Handler is unbuffered, meaning the
 		// CheckPanic will block trying to write a log event until handler.Next() is
 		// called.
 		defer func() {
@@ -230,7 +231,7 @@ func TestSync(t *testing.T) {
 	logger := NewLogger()
 	defer logger.Stop()
 
-	handler := NewChannelHandler()
+	handler := channel.NewHandler()
 	logger.AddHandler("TestEvent", handler)
 
 	var lastHandledEventId uint64
@@ -267,7 +268,7 @@ func TestSetStackMinLevel(t *testing.T) {
 	logger := NewLogger()
 	defer logger.Stop()
 
-	handler := NewChannelHandler()
+	handler := channel.NewHandler()
 	logger.AddHandler("TestSetStackMinLevel", handler)
 	logger.SetStackMinLevel(ErrorLevel)
 

--- a/logger_writer_test.go
+++ b/logger_writer_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/phemmer/sawmill/event"
+	"github.com/phemmer/sawmill/handler/channel"
 )
 
 func TestNewWriter(t *testing.T) {
-	handler := NewChannelHandler()
+	handler := channel.NewHandler()
 	logger := NewLogger()
 	defer logger.Stop()
 	logger.AddHandler("TestNewWriter", handler)


### PR DESCRIPTION
The Channel and Capture handlers were written for `sawmill`'s local test suite. They're also useful in the test suites of external projects using `sawmill`.

This PR moves the handlers out of `sawmill`'s test suite and exports them as regular handlers alongside `sentry`, `splunk`, etc. It also updates the tests for the `filter` handler and the top-level package tests to dog-food these handlers instead of using local implementations.
